### PR TITLE
feat:Add api in docker-compose and adjusting db in connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.21-alpine3.18
+
+WORKDIR /app
+
+COPY . .
+
+WORKDIR /app/cmd/api
+
+RUN go get -d -v ./...
+
+RUN go build -o api .
+
+EXPOSE 3000
+
+CMD ["./api"]

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	connectionString := "postgresql://posts:p0stgr3s@localhost:5432/posts"
+	connectionString := "postgresql://posts:p0stgr3s@db:5432/posts"
 	conn, err := database.NewConnection(connectionString)
 	if err != nil {
 		panic(err)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,3 +23,12 @@ services:
       - "3001:8081" 
     environment:
       - PGWEB_DATABASE_URL=postgresql://posts:p0stgr3s@db:5432/posts?sslmode=disable
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy


### PR DESCRIPTION
Opa! Tudo bem?

1. Adicionei a API no docker-compose
2. Ajustei o connection para receber o db que está no docker-compose

### Agora com um simples comando conseguimos rodar o banco e a API:

 ```bash
  docker-compose up
```

Aplicação rodando e gravando no banco:

![image](https://github.com/filhodanuvem/ytgoapi/assets/105388145/665bd22b-b5a9-49eb-bc57-a570cb12d1f5)

ps: Se deixei algo para trás, por favor comentar!
