### PR TITLE
fix: remove duplicated lines and lint execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ COPY . .
 
 RUN go get -d -v ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -o api ./cmd/api/main.go
-RUN CGO_ENABLED=0 GOOS=linux go build -o api ./cmd/api/main.go
 
 FROM scratch
 WORKDIR /
-COPY --from=builder /app/api ./
 COPY --from=builder /app/api ./
 EXPOSE 3000
 ENTRYPOINT ["./api"]


### PR DESCRIPTION
Linhas duplicadas foram removidas e executado lint que removeu extra space.